### PR TITLE
fix: detect and persist visitor language

### DIFF
--- a/app/components/LandingPage.tsx
+++ b/app/components/LandingPage.tsx
@@ -30,6 +30,11 @@ export default function LandingPage() {
   const [isHoveringBook, setIsHoveringBook] = useState(false)
   const { language, setLanguage } = useLanguage()
 
+  const selectLanguage = (selectedLanguage: 'cn' | 'en') => {
+    localStorage.setItem('languagePreference', selectedLanguage)
+    setLanguage(selectedLanguage)
+  }
+
   // Pre-generate stars deterministically
   const stars = useMemo(() => generateStars(100), [])
 
@@ -94,25 +99,27 @@ export default function LandingPage() {
       >
         {/* Creative Language Switcher */}
         <div className="flex items-center gap-2 font-mono text-xs tracking-widest text-white/30">
-          <button
-            onClick={() => setLanguage('cn')}
+          <Link
+            href="/"
+            onClick={() => selectLanguage('cn')}
             className={cn(
               'transition-colors duration-300 hover:text-white',
               language === 'cn' ? 'font-bold text-white' : ''
             )}
           >
             CN
-          </button>
+          </Link>
           <span>/</span>
-          <button
-            onClick={() => setLanguage('en')}
+          <Link
+            href="/en"
+            onClick={() => selectLanguage('en')}
             className={cn(
               'transition-colors duration-300 hover:text-white',
               language === 'en' ? 'font-bold text-white' : ''
             )}
           >
             EN
-          </button>
+          </Link>
         </div>
 
         <Link

--- a/app/components/LanguageSwitcher.tsx
+++ b/app/components/LanguageSwitcher.tsx
@@ -7,12 +7,17 @@ import { cn } from '@/lib/utils'
 export default function LanguageSwitcher({ className }: { className?: string }) {
   const { language, setLanguage } = useLanguage()
 
+  const selectLanguage = (selectedLanguage: 'cn' | 'en') => {
+    localStorage.setItem('languagePreference', selectedLanguage)
+    setLanguage(selectedLanguage)
+  }
+
   return (
     <div className={cn('flex items-center gap-2', className)}>
       <Button
         variant="ghost"
         size="sm"
-        onClick={() => setLanguage('cn')}
+        onClick={() => selectLanguage('cn')}
         className={cn(
           'font-serif transition-colors',
           language === 'cn' ? 'font-bold text-amber-600' : 'text-stone-500 hover:text-stone-900'
@@ -24,7 +29,7 @@ export default function LanguageSwitcher({ className }: { className?: string }) 
       <Button
         variant="ghost"
         size="sm"
-        onClick={() => setLanguage('en')}
+        onClick={() => selectLanguage('en')}
         className={cn(
           'font-serif transition-colors',
           language === 'en' ? 'font-bold text-amber-600' : 'text-stone-500 hover:text-stone-900'

--- a/app/components/SetLanguage.tsx
+++ b/app/components/SetLanguage.tsx
@@ -1,14 +1,33 @@
 'use client'
 
 import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
 import { useLanguage } from '@/app/context/LanguageContext'
 
-export default function SetLanguage({ lang }: { lang: 'en' | 'cn' }) {
+export default function SetLanguage({ lang }: { lang: 'en' | 'cn' | 'auto' }) {
   const { setLanguage } = useLanguage()
+  const router = useRouter()
 
   useEffect(() => {
-    setLanguage(lang)
-  }, [lang, setLanguage])
+    if (lang !== 'auto') {
+      setLanguage(lang)
+      return
+    }
+
+    const savedLanguage = localStorage.getItem('languagePreference')
+    const detectedLanguage = navigator.languages.some((language) =>
+      language.toLowerCase().startsWith('zh')
+    )
+      ? 'cn'
+      : 'en'
+    const preferredLanguage =
+      savedLanguage === 'cn' || savedLanguage === 'en' ? savedLanguage : detectedLanguage
+
+    setLanguage(preferredLanguage)
+    if (preferredLanguage === 'en') {
+      router.replace('/en')
+    }
+  }, [lang, router, setLanguage])
 
   return null
 }

--- a/app/context/LanguageContext.tsx
+++ b/app/context/LanguageContext.tsx
@@ -1,6 +1,7 @@
 'use client'
 
-import React, { createContext, useContext, useState, useEffect } from 'react'
+import React, { createContext, useCallback, useContext, useEffect, useState } from 'react'
+import { usePathname } from 'next/navigation'
 
 type Language = 'en' | 'cn'
 
@@ -62,19 +63,25 @@ export const translations = {
 }
 
 export function LanguageProvider({ children }: { children: React.ReactNode }) {
-  const [language, setLanguage] = useState<Language>('cn')
+  const pathname = usePathname()
+  const routeLanguage: Language | null = pathname === '/en' ? 'en' : pathname === '/' ? 'cn' : null
+  const [language, setLanguage] = useState<Language>(routeLanguage ?? 'cn')
 
   useEffect(() => {
+    // The language-specific landing routes take precedence over a previously saved preference.
+    if (routeLanguage) return
+
     const savedLang = localStorage.getItem('language') as Language
-    if (savedLang) {
+    if (savedLang === 'en' || savedLang === 'cn') {
       setLanguage(savedLang)
     }
-  }, [])
+  }, [routeLanguage])
 
-  const handleSetLanguage = (lang: Language) => {
+  const handleSetLanguage = useCallback((lang: Language) => {
     setLanguage(lang)
     localStorage.setItem('language', lang)
-  }
+    document.documentElement.lang = lang === 'cn' ? 'zh-CN' : 'en'
+  }, [])
 
   const t = (key: string) => {
     // @ts-expect-error: Dynamic key access on translations object

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,7 @@ import SetLanguage from '@/app/components/SetLanguage'
 export default function Home() {
   return (
     <>
-      <SetLanguage lang="cn" />
+      <SetLanguage lang="auto" />
       <LandingPage />
     </>
   )


### PR DESCRIPTION
## Summary
- fix landing-page CN/EN switching and canonical language routes
- detect the browser language for first-time visitors
- preserve explicit language choices separately from legacy defaults
- keep the document language attribute synchronized

## Validation
- `bun run lint`
- `bun run build`
- `bun run format:check`
- manually verified CN → EN, EN refresh, and EN → CN in local preview