### PR TITLE
Sync English landing page copy

### DIFF
--- a/app/framework/LandingPage.tsx
+++ b/app/framework/LandingPage.tsx
@@ -20,8 +20,8 @@ const copy = {
   },
   en: {
     eyebrow: 'ITALO CALVINO / DIGITAL EXPERIMENTS',
-    lead: 'We do not explain Calvino.',
-    leadAccent: 'We enter him.',
+    lead: 'Where reading ends,',
+    leadAccent: 'another world begins to grow.',
     index: 'Works index',
     enter: 'Enter the work',
     soon: 'In construction',


### PR DESCRIPTION
## Summary
- replace the ambiguous English landing-page headline
- align the English copy with the updated Chinese headline

## Validation
- npm run build
- git diff --check